### PR TITLE
Added type parameter to HalResource interface

### DIFF
--- a/halarious-core/src/main/java/ch/halarious/core/HalResource.java
+++ b/halarious-core/src/main/java/ch/halarious/core/HalResource.java
@@ -20,5 +20,5 @@ package ch.halarious.core;
  *
  * @author surech
  */
-public interface HalResource {
+public interface HalResource <T> {
 }


### PR DESCRIPTION
This would address issue #13 by allowing type adapters to be registered using the optional type parameter of the HalResource interface.

Example usage:
```java
GsonBuilder builder = new GsonBuilder();
builder.registerTypeAdapter(HalResource.class, new HalSerializer());
builder.registerTypeAdapter(new TypeToken<HalResource<FirstModelResource>>(){}.getType(), new HalDeserializer(FirstModelResource.class));
builder.registerTypeAdapter(new TypeToken<HalResource<SecondModelResource>>(){}.getType(), new HalDeserializer(SecondModelResource.class));
builder.setExclusionStrategies(new HalExclusionStrategy());
Gson gson = builder.create();
```