### PR TITLE
Give empty list when embedded/link node is null

### DIFF
--- a/halarious-core/src/main/java/ch/halarious/core/HalDeserializer.java
+++ b/halarious-core/src/main/java/ch/halarious/core/HalDeserializer.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonParseException;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -133,7 +134,8 @@ public class HalDeserializer implements JsonDeserializer<HalResource> {
                 // Collection auslesen
                 Collection collection = (Collection) HalReflectionHelper.getValue(field, result);
                 if (collection == null) {
-                    throw new HalDeserializingException("Collection is null; no values can be added");
+                    collection = new ArrayList<>();
+                    HalReflectionHelper.setValue(result, field, collection);
                 }
 
                 JsonArray jsonArray = jsonField.getAsJsonArray();
@@ -159,18 +161,19 @@ public class HalDeserializer implements JsonDeserializer<HalResource> {
                 }
             }
         } else if (Collection.class.isAssignableFrom(field.getType())) {
-        	
-        	Collection collection = (Collection) HalReflectionHelper.getValue(field, result);
-        	
+            
+            Collection collection = (Collection) HalReflectionHelper.getValue(field, result);
+            
             // Generischer Type auslesen
             ParameterizedType gType = (ParameterizedType) field.getGenericType();
             Type[] actualTypeArguments = gType.getActualTypeArguments();
 
             if (collection == null) {
-                throw new HalDeserializingException("Collection is null; no values can be added");
+                collection = new ArrayList<>();
+                HalReflectionHelper.setValue(result, field, collection);
             }
 
-        	// Wir erwarten ein JSON-Array
+            // Wir erwarten ein JSON-Array
             if (jsonField.isJsonArray()) {
 
                 JsonArray jsonArray = jsonField.getAsJsonArray();
@@ -183,7 +186,7 @@ public class HalDeserializer implements JsonDeserializer<HalResource> {
             }
             else if(jsonField.isJsonObject())
             {
-            	writeEmbeddedInCollection(collection, actualTypeArguments[0], jsonField, context);
+                writeEmbeddedInCollection(collection, actualTypeArguments[0], jsonField, context);
             }
         }
     }

--- a/halarious-core/src/test/java/ch/halarious/core/HalDeserializerTest.java
+++ b/halarious-core/src/test/java/ch/halarious/core/HalDeserializerTest.java
@@ -27,9 +27,9 @@ import org.junit.Test;
  * @author surech
  */
 public class HalDeserializerTest {
-    
+
     private Gson gson;
-    
+
     @Before
     public void before() {
         // GSON erstellen
@@ -104,7 +104,7 @@ public class HalDeserializerTest {
 
     @Test
     public void testHalResourceCollection() {
-        String json = "{ \"_links\":{ \"reference\":{ \"href\":\"/path/3141\", \"title\":\"Ein Titel\" } }, \"_embedded\":{ \"resource\":{ \"filledText\":\"Inneres Objekt\" }, \"test\":[ { \"_links\":{ \"self\": { \"href\": \"/path/2717\" } }, \"filledText\":\"Erstes Objekt\" }, { \"filledText\":\"Zweites Objekt\" } ] }, \"filledText\":\"Ein Text\" } ";
+        String json = "{ \"_links\":{ \"reference\":{ \"href\":\"/path/3141\", \"title\":\"Ein Titel\" } }, \"_embedded\":{ \"resource\":{ \"filledText\":\"Inneres Objekt\" }, \"test\":[ { \"_links\":{ \"self\": { \"href\": \"/path/2717\" } }, \"filledText\":\"Erstes Objekt\" }, { \"filledText\":\"Zweites Objekt\" } ], \"test2\":[ { \"_links\":{ \"self\": { \"href\": \"/path/2718\" } }, \"filledText\":\"Dritte Objekt\" }, { \"filledText\":\"Vierte Objekt\" } ], \"filledText\":\"Ein Text\" } }";
         TestResource result = (TestResource) gson.fromJson(json, HalResource.class);
 
         // Überprüfen
@@ -114,15 +114,18 @@ public class HalDeserializerTest {
         Assert.assertEquals("/path/2717", result.getResources().get(0).getLinkText());
         Assert.assertEquals("Erstes Objekt", result.getResources().get(0).getFilledText());
         Assert.assertEquals("Zweites Objekt", result.getResources().get(1).getFilledText());
+        Assert.assertEquals("/path/2718", result.getNullResources().get(0).getLinkText());
+        Assert.assertEquals("Dritte Objekt", result.getNullResources().get(0).getFilledText());
+        Assert.assertEquals("Vierte Objekt", result.getNullResources().get(1).getFilledText());
     }
-    
+
     @Test
     public void testHalResourceObjectToCollection() {
-    	String json = "{\"_embedded\": { \"test\":{ \"_links\":{ \"self\": { \"href\": \"/path/2717\" }}}}, \"filledText\":\"Ein Text\" }";
-    	
-    	TestResource result = (TestResource) gson.fromJson(json, HalResource.class);
-    	
-    	Assert.assertEquals("Ein Text", result.getFilledText());
-    	Assert.assertEquals("/path/2717", result.getResources().get(0).getLinkText());
+        String json = "{\"_embedded\": { \"test\":{ \"_links\":{ \"self\": { \"href\": \"/path/2717\" }}}}, \"filledText\":\"Ein Text\" }";
+
+        TestResource result = (TestResource) gson.fromJson(json, HalResource.class);
+
+        Assert.assertEquals("Ein Text", result.getFilledText());
+        Assert.assertEquals("/path/2717", result.getResources().get(0).getLinkText());
     }
 }

--- a/halarious-core/src/test/java/ch/halarious/core/HalDeserializerTest.java
+++ b/halarious-core/src/test/java/ch/halarious/core/HalDeserializerTest.java
@@ -79,7 +79,7 @@ public class HalDeserializerTest {
 
     @Test
     public void testHalReferenceCollection() {
-        String json = "{ \"_links\":{ \"reference\":{ \"href\":\"/path/3141\", \"title\":\"Ein Titel\" }, \"linkList\":[ { \"href\":\"/link/452\" }, { \"href\":\"/link/832\", \"title\":\"Noch ein Link\" } ] }, \"filledText\":\"Ein Text\" } ";
+        String json = "{ \"_links\":{ \"reference\":{ \"href\":\"/path/3141\", \"title\":\"Ein Titel\" }, \"linkList\":[ { \"href\":\"/link/452\" }, { \"href\":\"/link/832\", \"title\":\"Noch ein Link\" } ], \"linkList2\":[ { \"href\":\"/link/453\" }, { \"href\":\"/link/833\", \"title\":\"Noch ein Link\" } ], \"filledText\":\"Ein Text\" } }";
         TestResource result = (TestResource) gson.fromJson(json, HalResource.class);
 
         // Überprüfen
@@ -90,6 +90,10 @@ public class HalDeserializerTest {
         Assert.assertEquals("/link/452", result.getLinkList().get(0).getHref());
         Assert.assertEquals("/link/832", result.getLinkList().get(1).getHref());
         Assert.assertEquals("Noch ein Link", result.getLinkList().get(1).getTitle());
+        Assert.assertEquals(2, result.getNullLinkList().size());
+        Assert.assertEquals("/link/453", result.getNullLinkList().get(0).getHref());
+        Assert.assertEquals("/link/833", result.getNullLinkList().get(1).getHref());
+        Assert.assertEquals("Noch ein Link", result.getNullLinkList().get(1).getTitle());
     }
 
     @Test

--- a/halarious-core/src/test/java/ch/halarious/core/TestResource.java
+++ b/halarious-core/src/test/java/ch/halarious/core/TestResource.java
@@ -26,7 +26,7 @@ public class TestResource implements HalResource {
 
     private String nullText = null;
 
-    private String filledText = "test";
+    private String filledText = "Ein Text";
 
     @HalLink(name = "self", title = "Test")
     private String linkText = "link";
@@ -39,10 +39,16 @@ public class TestResource implements HalResource {
 
     private List<HalReference> linkList = new ArrayList<>();
 
+    @HalLink(name = "linkList2")
+    private List<HalReference> nullLinkList;
+
     private TestResource resource = null;
 
     @HalEmbedded(name = "test")
     private List<TestResource> resources = new ArrayList<>();
+
+    @HalEmbedded(name = "test2")
+    private List<TestResource> nullResources;
 
     @HalEmbedded(name = "children")
     private List<TestChildResource> children = new ArrayList<>();
@@ -81,6 +87,14 @@ public class TestResource implements HalResource {
 
     public List<TestResource> getResources() {
         return resources;
+    }
+
+    public List<TestResource> getNullResources() {
+        return nullResources;
+    }
+
+    public List<HalReference> getNullLinkList() {
+        return nullLinkList;
     }
 
     public List<TestChildResource> getChildren() {


### PR DESCRIPTION
There is a discuss inside issue https://github.com/surech/halarious/issues/18
I found we need to initialize List of our model data
If we try to map to 
```
 @HalEmbedded(name = "test")
  private List<TestResource> resources;
```
It will crash.
We can do it inside the lib actually.
